### PR TITLE
Install APCu stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ php:
   - 5.6
 
 before_script:
-    - printf "\n" | pecl install apcu-beta
+    - printf "\n" | pecl install apcu
     - echo "apc.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - composer install


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
